### PR TITLE
Update CSS to override Limechat's effect class background color values

### DIFF
--- a/Colloquial-Lance.css
+++ b/Colloquial-Lance.css
@@ -161,7 +161,11 @@ div[type=system] span.time
 .effect[bgcolor-number='0'] {}
 .effect[bgcolor-number='1'] {}
 .effect[bgcolor-number='2'] {}
-.effect[bgcolor-number='3'] {}
+.effect[bgcolor-number='3'] {
+  background-color: #fff;
+  border-bottom: solid 1px #fff;
+  color: #000;
+}
 .effect[bgcolor-number='4'] {}
 .effect[bgcolor-number='5'] {}
 .effect[bgcolor-number='6'] {}


### PR DESCRIPTION
Fixes case where the default highlighting from LimeChat overrides the custom theme:

Something like:

```
<span class="effect" style="" color-number="0" bgcolor-number="3">text here</span>
```

Where the background color and color values are not defined in this theme's CSS yet.